### PR TITLE
Give client more control over how waits occur on paged get_range calls

### DIFF
--- a/c_src/resources.h
+++ b/c_src/resources.h
@@ -31,7 +31,8 @@ typedef enum _ErlFDBFutureType {
     ErlFDB_FT_VALUE,
     ErlFDB_FT_STRING_ARRAY,
     ErlFDB_FT_KEYVALUE_ARRAY,
-    ErlFDB_FT_MAPPEDKEYVALUE_ARRAY
+    ErlFDB_FT_MAPPEDKEYVALUE_ARRAY,
+    ErlFDB_FT_KEY_ARRAY
 } ErlFDBFutureType;
 
 typedef struct _ErlFDBFuture {

--- a/src/erlfdb_key.erl
+++ b/src/erlfdb_key.erl
@@ -20,7 +20,9 @@
     first_greater_than/1,
     first_greater_or_equal/1,
 
-    strinc/1
+    strinc/1,
+
+    list_to_ranges/1
 ]).
 
 to_selector(<<_/binary>> = Key) ->
@@ -59,3 +61,13 @@ rstrip_ff(Key) ->
         16#FF -> rstrip_ff(binary:part(Key, {0, KeyLen - 1}));
         _ -> Key
     end.
+
+list_to_ranges(Array) when length(Array) < 2 ->
+    erlang:error(badarg);
+list_to_ranges(Array) ->
+    list_to_ranges(Array, []).
+
+list_to_ranges([_EK], Acc) ->
+    lists:reverse(Acc);
+list_to_ranges([SK, EK | T], Acc) ->
+    list_to_ranges([EK | T], [{SK, EK} | Acc]).

--- a/src/erlfdb_nif.erl
+++ b/src/erlfdb_nif.erl
@@ -42,6 +42,7 @@
     transaction_get_key/3,
     transaction_get_addresses_for_key/2,
     transaction_get_range/9,
+    transaction_get_range_split_points/4,
     transaction_get_mapped_range/10,
     transaction_set/3,
     transaction_clear/2,
@@ -114,6 +115,7 @@
     | not_found
     | []
     | [{key(), value()}]
+    | [{{key(), value()}, {key(), key()}, list({key(), value()})}]
     | ok.
 
 -type network_option() ::
@@ -375,6 +377,25 @@ transaction_get_range(
         Reverse
     ).
 
+-spec transaction_get_range_split_points(
+    transaction(),
+    StartKey :: binary(),
+    EndKey :: binary(),
+    ChunkSize :: non_neg_integer()
+) -> future().
+transaction_get_range_split_points(
+    {erlfdb_transaction, Tx},
+    StartKey,
+    EndKey,
+    ChunkSize
+) ->
+    erlfdb_transaction_get_range_split_points(
+        Tx,
+        StartKey,
+        EndKey,
+        ChunkSize
+    ).
+
 -spec transaction_get_mapped_range(
     transaction(),
     StartKeySelector :: key_selector(),
@@ -625,6 +646,13 @@ erlfdb_transaction_get_range(
     _Iteration,
     _Snapshot,
     _Reverse
+) ->
+    ?NOT_LOADED.
+erlfdb_transaction_get_range_split_points(
+    _Transaction,
+    _StartKey,
+    _EndKey,
+    _ChunkSize
 ) ->
     ?NOT_LOADED.
 erlfdb_transaction_get_mapped_range(


### PR DESCRIPTION
* wait_for_all_interleaving: Given a list of fold_future() or future(), calling this function will wait on the futures at once, and then continue to issue any remaning get_range or get_mapped_range until the result set is exhausted. This allows fdbserver to process multiple get_ranges at the same time, in a pipelined fashion.

* get_range_split_points: Companion to wait_for_all_interleaving, this is an fdbserver function that will split a given key range into a partitioning set of ranges for which the key-values for each section are approximately equal to the given `chunk_size` option. There are limitations to this, namely that a hard maximum of 100 shards can be traversed.

* get_range: Make the default behavior of get_range more explicit in the type specs and with the `wait` option, with defaults to true. A value of `false` will return a fold_future(), while `interleaving` is an experimental feature that will use the features above when retrieving the range.

For #19 