### PR TITLE
Flush ready messages from foregone futures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog for v0.x
 
-## v0.2.1 (TBD)
+## v0.2.2 (TBD)
+
+### Bug fixes
+
+  * (#31) Previously, erlfdb could leak `{reference(), ready}` messages to the caller if
+    the transaction UserFun was executed more than once. We will now flush such messages before
+    `transactional/2` returns control to the caller. Watches are unaffected.
+
+## v0.2.1 (2024-11-20)
 
 ### Testing
 

--- a/c_src/resources.h
+++ b/c_src/resources.h
@@ -41,7 +41,6 @@ typedef struct _ErlFDBFuture {
     ErlNifPid pid;
     ErlNifEnv *pid_env;
     ErlNifEnv *msg_env;
-    ERL_NIF_TERM tx_ref;
     ERL_NIF_TERM msg_ref;
     ErlNifMutex *lock;
     bool cancelled;

--- a/c_src/resources.h
+++ b/c_src/resources.h
@@ -41,6 +41,7 @@ typedef struct _ErlFDBFuture {
     ErlNifPid pid;
     ErlNifEnv *pid_env;
     ErlNifEnv *msg_env;
+    ERL_NIF_TERM tx_ref;
     ERL_NIF_TERM msg_ref;
     ErlNifMutex *lock;
     bool cancelled;

--- a/dev/DEV.md
+++ b/dev/DEV.md
@@ -1,12 +1,33 @@
-Developing in erlfdb
-====================
+# Developing in erlfdb
 
-.clangd config
---------------
+## C NIF - clang-format
+
+This section describes minimal steps for working with clang-format, which is used to
+apply consistent code formatting to the .c files. 
+
+### Installation
+
+Here's an example installation on a macOS system.
+
+```bash
+brew install clang-format
+```
+
+Often clang-format can be used inside an IDE.
+
+### .clangd config
 
 The .clangd file cannot expand environment variables, so you should generate it
 with the provided script, which assumes you're using asdf.
 
 ```bash
 ./dev/gen-clangd-config.sh > .clangd
+```
+
+### Example run
+
+To reformat a file in-place, execute the following.
+
+```bash
+clang-format -i c_src/main.c
 ```


### PR DESCRIPTION
Closes #31 

Ready message for a watch remains of the form `{reference(), ready}`.

All other interactions will present `{{TxRef :: reference(), reference()}, ready}`.

When a transaction does not complete successfully on the first attempt, a flush is made for any remaining ready messages on the message queue.

A unit test exercises this with a fake not_committed error.